### PR TITLE
UUID support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: 0.11.0
-          args: -- --test-threads 1
+          args: --all-features -- --test-threads 1
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
@@ -128,6 +128,15 @@ jobs:
         with:
           command: test
           args: --release
+
+      - name: Run cargo test --all-features --release
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
+        with:
+          command: test
+          args: --all-features --release
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "cmac",
  "crypto-mac",
  "subtle 2.2.2",
+ "uuid",
  "zeroize",
 ]
 
@@ -121,6 +122,12 @@ name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,12 @@ block-cipher-trait = "0.6"
 cmac = "0.2"
 crypto-mac = { version = "0.7", default-features = false }
 subtle = { version = "2", default-features = false }
+uuid = { version = "0.8", optional = true, default-features = false }
 zeroize = "1"
 
 [features]
 default = ["aes"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Adds `encrypt_to_uuid` and `decrypt_from_uuid` methods gated under the (off-by-default) `uuid` cargo feature.